### PR TITLE
types end up in dist so they must be deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "license": "MIT",
   "dependencies": {
+    "@octokit/core": "^2.1.0",
     "@octokit/request-error": "^1.2.0",
     "@octokit/types": "^2.0.1"
   },
   "devDependencies": {
-    "@octokit/core": "^2.1.0",
     "@octokit/rest": "^16.24.2",
     "@pika/pack": "^0.5.0",
     "@pika/plugin-build-node": "^0.6.1",


### PR DESCRIPTION
I was getting a build error because     "@octokit/core": "^2.1.0", was not installed