### PR TITLE
fix(README): Replace Pika CDN with Skypack CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ As a compromise, this plugin is reverting changes such as the one above to remai
 Browsers
 </th><td width=100%>
 
-Load `@octokit/plugin-enterprise-compatibility` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.pika.dev](https://cdn.pika.dev)
+Load `@octokit/plugin-enterprise-compatibility` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.skypack.dev](https://cdn.skypack.dev)
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.pika.dev/@octokit/core";
-  import { enterpriseCompatibility } from "https://cdn.pika.dev/@octokit/plugin-enterprise-compatibility";
+  import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
+  import { enterpriseCompatibility } from "https://cdn.skypack.dev/@octokit/plugin-enterprise-compatibility";
 </script>
 ```
 


### PR DESCRIPTION
Fixes #167 
* Replaced "cdn.pika.dev" with "cdn.skypack.dev" in README