### PR TITLE
build(npm): replace 'pika' command with 'pika-pack'

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "Octokit plugin for improving GHE compatibility",
   "scripts": {
-    "build": "pika build",
+    "build": "pika-pack build",
     "generate-routes": "node scripts/generate-routes",
     "lint": "prettier --check 'src/*' 'test/*' README.md package.json",
     "lint:fix": "prettier --write 'src/*' 'test/*' README.md package.json",


### PR DESCRIPTION
# Description
Replace build script in package.json from `pika build` to `pika-pack build.`
You can read more about this in [Pika Release Notes](https://github.com/FredKSchott/pika-pack/releases/tag/v0.5.0)
	  
# Context
Avoid Release issues like the one reported [here](https://github.com/octokit/plugin-retry.js/issues/321)
	  